### PR TITLE
Add Dependabot updates to Github Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+       ci-dependencies:
+          patterns:
+            - "*" # Match all CI dependencies to one PR.


### PR DESCRIPTION
Automatically create update PR for Github Actions workflows, like actions/checkout or actions/setup-dart.

To avoid update spam, only updates them once a month & groups the updates into one pull request. Simply stops the actions versions from growing old.

There already are some older action versions in use, causing warnings in CI runs like:

"Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20"